### PR TITLE
add gov proposal to lower deposit requirement

### DIFF
--- a/proposals/2021-04-lower-deposit-requirement/README.md
+++ b/proposals/2021-04-lower-deposit-requirement/README.md
@@ -43,6 +43,10 @@ __Wait for the Cosmos Hub to adopt proposed changes to the Governance module for
 
 These initiatives should not be mutually exclusive. While research and development of these features is ongoing, the Cosmos Hub will benefit from this parameter change today, as well as the prescedent it sets for self-improving governance.
 
+__Since the ATOM price fluctuates with respect to USD, make proposal thresholds reference a stable price oracle__
+
+This is an interesting design space, however it becomes more plausible if and when the Cosmos Hub adds a decentralized exchange that can be used to produce a reference rate. Lowering the proposal threshold is a temporary solution that will help in the short-term.
+
 ## Governance Votes
 
 The following items summarize the voting options and what it means for this proposal.

--- a/proposals/2021-04-lower-deposit-requirement/README.md
+++ b/proposals/2021-04-lower-deposit-requirement/README.md
@@ -25,6 +25,8 @@ Credit to Gavin Birch (Figment Networks) and the Cosmos Governance Working Group
 
 Change the minimum proposal deposit requirement from 512 ATOMs (aprox. $10,000 USD) to 64 ATOMs (aprox. $1,300 USD).
 
+Note: Parameters are denominated in micro-ATOMs, as described in the [governance parameter list](https://github.com/cosmos/governance/blob/master/params-change/Governance.md).
+
 ## Risks
 
 __This change makes it easier to submit spam proposals.__
@@ -46,6 +48,6 @@ These initiatives should not be mutually exclusive. While research and developme
 The following items summarize the voting options and what it means for this proposal.
 
 - **YES**: You approve the parameter change proposal to decrease the governance proposal deposit requirements from 512 to 64 ATOMs.
-- **NO**: You request the proposed value of 64 ATOMs be changed, but agree that the minnimum deposit requirement should be lowered.
-- **NO WITH VETO**: You believe the current deposit value should be kept as-is.
+- **NO**: You disapprove of the parameter change in it's current form (please indicate in the Cosmos Forum why this is the case).
+- **NO WITH VETO**: You are strongly opposed to this change and will exit the network if passed.
 - **ABSTAIN**: You are impartial to the outcome of the proposal.

--- a/proposals/2021-04-lower-deposit-requirement/README.md
+++ b/proposals/2021-04-lower-deposit-requirement/README.md
@@ -1,0 +1,51 @@
+# Parameter change: lower minimum proposal deposit amount
+
+## Summary
+
+The current deposit amount of 512 ATOMs prohibits valuable governance activity from small holders or those with most of their ATOM staked. We propose lowering the requirment to 64 ATOMS.
+
+## Objectives
+
+1. Enable community members with good ideas but little capital to participate in governance and request resources from the community pool treasury.
+2. Improve the governance UX for holders who keep most of their ATOM staked.
+3. Increase utilization of treasury (currently 666,457 ATOM, approximately $14 MM USD, at time of writing).
+4. Accelerate Cosmos Hub development and growth.
+
+## Background
+
+Current deposit is 512 ATOMs (approximately $10k USD today). The ATOM price when the community treasury was activated (2019-05-03) was $4.99 (source: CoinMarketCap), meaning the total required deposit to submit a proposal was $2,555. Today, most proposers must coordinate with large ATOM holders to request additional funds in order to meet the minimum deposit requirements. This also applies to large ATOM holders who want to be active in governance but do not have enough liquid ATOM to meet the deposit requirements, as staked ATOM cannot be used to post deposits.
+
+## Proposers
+
+Federico Kunze Küllmer (Tharsis) and Sam Hart (Interchain).
+
+Credit to Gavin Birch (Figment Networks) and the Cosmos Governance Working Group (GWG) for initiating a recent conversation that motivated this proposal.
+
+## Proposed Parameter Change
+
+Change the minimum proposal deposit requirement from 512 ATOMs (aprox. $10,000 USD) to 64 ATOMs (aprox. $1,300 USD).
+
+## Risks
+
+__This change makes it easier to submit spam proposals.__
+
+While this is true, in order to fully mitigate spam the Cosmos Hub must increase the minimum deposit required for proposal [submission](https://cosmoscan.net/proposal/28).
+
+__By increasing the number of submissions, voter participation or the level of consideration given to each proposal may decrease.__
+
+We believe this is a justifiable trade-off for promoting more community-driven initiatives and enthusiasm for advancing Cosmos. As we lower the barrier to entry for governance participation, we invite community members to take this opportunity to enact more effective and efficient governance practices. The upcoming Groups, Authz, and Interchain Accounts modules will provide powerful abstractions to this end.
+
+## Alternatives
+
+__Wait for the Cosmos Hub to adopt proposed changes to the Governance module for variable deposit amounts, quorom thresholds, and voting periods.__
+
+These initiatives should not be mutually exclusive. While research and development of these features is ongoing, the Cosmos Hub will benefit from this parameter change today, as well as the prescedent it sets for self-improving governance.
+
+## Governance Votes
+
+The following items summarize the voting options and what it means for this proposal.
+
+- **YES**: You approve the parameter change proposal to decrease the governance proposal deposit requirements from 512 to 64 ATOMs.
+- **NO**: You request the proposed value of 64 ATOMs be changed, but agree that the minnimum deposit requirement should be lowered.
+- **NO WITH VETO**: You believe the current deposit value should be kept as-is.
+- **ABSTAIN**: You are impartial to the outcome of the proposal.

--- a/proposals/2021-04-lower-deposit-requirement/README.md
+++ b/proposals/2021-04-lower-deposit-requirement/README.md
@@ -48,6 +48,6 @@ These initiatives should not be mutually exclusive. While research and developme
 The following items summarize the voting options and what it means for this proposal.
 
 - **YES**: You approve the parameter change proposal to decrease the governance proposal deposit requirements from 512 to 64 ATOMs.
-- **NO**: You disapprove of the parameter change in it's current form (please indicate in the Cosmos Forum why this is the case).
+- **NO**: You disapprove of the parameter change in its current form (please indicate in the Cosmos Forum why this is the case).
 - **NO WITH VETO**: You are strongly opposed to this change and will exit the network if passed.
 - **ABSTAIN**: You are impartial to the outcome of the proposal.

--- a/proposals/2021-04-lower-deposit-requirement/proposal.json
+++ b/proposals/2021-04-lower-deposit-requirement/proposal.json
@@ -3,8 +3,8 @@
   "description": "The current deposit amount of 512 ATOMs prohibits valuable governance activity from small holders or those with most of their ATOM staked. We propose lowering the requirment to 64 ATOMS.",
   "changes": [
     {
-      "subspace": "depositparams",
-      "key":"mindeposit",
+      "subspace": "mindeposit",
+      "key":"depositparams",
       "value": "64000000"
     }
   ],

--- a/proposals/2021-04-lower-deposit-requirement/proposal.json
+++ b/proposals/2021-04-lower-deposit-requirement/proposal.json
@@ -1,0 +1,17 @@
+{
+  "title": "Parameter change: lower minimum proposal deposit amount",
+  "description": "The current deposit amount of 512 ATOMs prohibits valuable governance activity from small holders or those with most of their ATOM staked. We propose lowering the requirment to 64 ATOMS.",
+  "changes": [
+    {
+      "subspace": "depositparams",
+      "key":"mindeposit",
+      "value": "64000000"
+    }
+  ],
+  "deposit": [
+    {
+      "denom": "uatom",
+      "amount": "1000000"
+    }
+  ]
+}

--- a/proposals/2021-04-lower-deposit-requirement/proposal.json
+++ b/proposals/2021-04-lower-deposit-requirement/proposal.json
@@ -3,9 +3,16 @@
   "description": "The current deposit amount of 512 ATOMs prohibits valuable governance activity from small holders or those with most of their ATOM staked. We propose lowering the requirment to 64 ATOMS.",
   "changes": [
     {
-      "subspace": "mindeposit",
+      "subspace": "gov",
       "key":"depositparams",
-      "value": "64000000"
+      "value": {
+        "min_deposit": [
+          {
+            "denom": "uatom",
+            "amount": "64000000"
+          }
+        ]
+      }
     }
   ],
   "deposit": [


### PR DESCRIPTION
This proposal follows a discussion in the Governance Working Group Telegram about lowering the deposit requirements for moving a proposal into the voting period.

[rendered](https://github.com/cosmos/governance/blob/lower-deposit-req/proposals/2021-04-lower-deposit-requirement/README.md)